### PR TITLE
Add Flock DB (Postgres)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ Flock is a social media platform.
 
 ```bash
 minikube start
+skaffold run -p infrastructure
 skaffold dev
+```
+
+When you are done:
+
+```bash
+skaffold delete -p infrastructure
 ```
 
 ## Curls

--- a/flock-api/skaffold.yaml
+++ b/flock-api/skaffold.yaml
@@ -1,7 +1,7 @@
 apiVersion: skaffold/v4beta1
 kind: Config
 metadata:
-  name: flock-api
+  name: flock-api-configuration
 build:
   artifacts:
     - image: flock-api

--- a/flock-db/flock-db.yaml
+++ b/flock-db/flock-db.yaml
@@ -1,16 +1,16 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: pg-cluster
+  name: flock-db
 spec:
-  instances: 1 # TODO: Change to 3 after development
+  instances: 1
   storage:
     size: 1Gi
   bootstrap:
     initdb:
-      database: pingdb
-      owner: pinguser
+      database: flockdb
+      owner: flockuser
       secret:
-        name: pinguser-secret
+        name: flockuser-secret
       postInitSQL:
-        - ALTER ROLE pinguser WITH LOGIN;
+        - ALTER ROLE flockuser WITH LOGIN;

--- a/flock-db/flock-db.yaml
+++ b/flock-db/flock-db.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: pg-cluster
+spec:
+  instances: 1 # TODO: Change to 3 after development
+  storage:
+    size: 1Gi
+  bootstrap:
+    initdb:
+      database: pingdb
+      owner: pinguser
+      secret:
+        name: pinguser-secret
+      postInitSQL:
+        - ALTER ROLE pinguser WITH LOGIN;

--- a/flock-db/secret.yaml
+++ b/flock-db/secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pinguser-secret
+  name: flockuser-secret
 type: Opaque
 stringData:
-  username: pinguser
-  password: ping123
+  username: flockuser
+  password: flock123

--- a/flock-db/secret.yaml
+++ b/flock-db/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pinguser-secret
+type: Opaque
+stringData:
+  username: pinguser
+  password: ping123

--- a/flock-db/skaffold.yaml
+++ b/flock-db/skaffold.yaml
@@ -1,0 +1,26 @@
+apiVersion: skaffold/v4beta1
+kind: Config
+metadata:
+  name: postgres-operator-installation
+deploy:
+  helm:
+    releases:
+      - name: cnpg
+        repo: https://cloudnative-pg.github.io/charts
+        remoteChart: cloudnative-pg
+        namespace: cnpg-system
+        createNamespace: true
+        wait: true
+---
+apiVersion: skaffold/v4beta1
+kind: Config
+metadata:
+  name: flock-db-configuration
+deploy:
+  kubectl:
+    flags:
+      apply: ["--namespace=default"]
+manifests:
+  rawYaml:
+    - secret.yaml
+    - flock-db.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -3,6 +3,7 @@ kind: Config
 metadata:
   name: flock
 
+# This configures the application
 requires:
   - configs:
       - flock-db-configuration
@@ -12,7 +13,8 @@ requires:
     path: flock-api/skaffold.yaml
 
 profiles:
-  - name: bootstrap
+  # This configures the infrastructure required for the application
+  - name: infrastructure
     patches:
       - op: replace
         path: /requires

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,5 +5,18 @@ metadata:
 
 requires:
   - configs:
-      - flock-api
+      - flock-db-configuration
+    path: flock-db/skaffold.yaml
+  - configs:
+      - flock-api-configuration
     path: flock-api/skaffold.yaml
+
+profiles:
+  - name: bootstrap
+    patches:
+      - op: replace
+        path: /requires
+        value:
+          - configs:
+              - postgres-operator-installation
+            path: flock-db/skaffold.yaml


### PR DESCRIPTION
## Summary

`flock-db` is a Postgres database that will be used to persist data in the application. It runs on k8s using [Cloud Native Postgres](https://cloudnative-pg.io/).

## Testing

Start the app:

```bash
minikube start
skaffold run -p infrastructure
skaffold dev
```

Check the operator and database are running:

```bash
kubectl get pods --all-namespaces | rg 'pg|db'
cnpg-system   cnpg-cloudnative-pg-75565d7678-4b58q   1/1     Running   0             5m16s
default       flock-db-1                             1/1     Running   0             94s
```