### PR TITLE
Programatically define the 'flock' realm

### DIFF
--- a/flock-kc/values.yaml
+++ b/flock-kc/values.yaml
@@ -13,3 +13,16 @@ replicaCount: 1
 auth:
   adminUser: admin
   adminPassword: password
+
+keycloakConfigCli:
+  enabled: true
+  configuration:
+    flock.json: |
+      {
+        "realm": "flock",
+        "enabled": true,
+        "registrationAllowed": true,
+        "loginWithEmailAllowed": true,
+        "duplicateEmailsAllowed": false,
+        "resetPasswordAllowed": true,
+      }


### PR DESCRIPTION
## Summary

Programatically define the `flock` realm

Solves https://github.com/flock-eng/flock/issues/6

## Change Log

- **Feature:** Use [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli) in [flock-kc/values.yaml](https://github.com/flock-eng/flock/blob/70df0fb711bd9f184565b5aeb7135cd6ca77b4d1/flock-kc/values.yaml#L17) to define `flock` realm with user registration enabled

## Testing

**Environment Setup:**

```bash
# Start the k8s cluster
minikube start

# Start the Database
skaffold run -p infrastructure -m postgres-operator-installation -m flock-db-configuration

# Inner Loop: test KeyCoak
skaffold dev -p infrastructure -m keycloak-installation

# Port-Forward KeyCloak
kubectl port-forward --namespace keycloak svc/keycloak 9091:80

# At this point, you go can on to test the new functionality. When you're done, proceed with cleanup.

# Cleanup Everything
skaffold delete -p infrastructure
 ```

**Functional Testing:**

Visit http://localhost:9091/ and login to the administrative realm:

```json
{ 
  "username": "admin",
  "password": "password"
}
```

Visit http://localhost:9091/admin/master/console/#/flock/realm-settings/login and see that user registration is enabled:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6c1dd78c-b8e1-4188-b3b1-d910b6a046e9">


Visit http://localhost:9091/realms/flock/account and register with a new account

| Login Page | Register Page |
|--------|--------|
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/aef3bee7-4dd1-46fe-834d-593bc168047c"> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/95c2dee9-4d0c-44a2-a453-2d4493f86c69"> | 

```json
{ 
  "username": "foo",
  "password": "bar",
  "email": "foo@bar.com",
  "first_name": "foo",
  "last_name": "bar"
}
```
Register your account, then 

| Account Page | Login Page |
|--------|--------|
| <img width="1728" alt="image" src="https://github.com/user-attachments/assets/58295a3a-dd40-42ab-afc3-5d362049b4d2"> | <img width="1728" alt="image" src="https://github.com/user-attachments/assets/de33508f-290f-4c8f-a17b-efaab2df6fd8"> |





