### PR TITLE
Build and Push Container Images to Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -1,0 +1,37 @@
+name: Build and Push Container Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and Push the flock-api image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./flock-api
+          file: ./flock-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: wcygan/flock-api:latest
+          cache-from: type=registry,ref=wcygan/flock-api:latest
+          cache-to: type=inline

--- a/flock-kc/values.yaml
+++ b/flock-kc/values.yaml
@@ -13,3 +13,16 @@ replicaCount: 1
 auth:
   adminUser: admin
   adminPassword: password
+
+keycloakConfigCli:
+  enabled: true
+  configuration:
+    flock.json: |
+      {
+        "realm": "flock",
+        "enabled": true,
+        "registrationAllowed": true,
+        "loginWithEmailAllowed": true,
+        "duplicateEmailsAllowed": false,
+        "resetPasswordAllowed": true,
+      }


### PR DESCRIPTION
## Summary

Build and Push Container Images to Docker Hub

Solves https://github.com/flock-eng/flock/issues/12

## Change Log

- **Feature:** add [publish-docker-images.yaml](https://github.com/flock-eng/flock/blob/83e63fe09807e39370261253004a76b4fe287dc4/.github/workflows/publish-docker-images.yaml) which is a GitHub Action to build and push container images to Docker Hub.

## Testing

N/A, AFAIK we cannot test GHA locally, so we will merge the PR and see what happens