### PR TITLE
Ingress Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .aider*
 .env
+repomix-output.txt
+**/.DS_Store

--- a/flock-api/flock-api.yaml
+++ b/flock-api/flock-api.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: flock-api
-          image: flock-api
+          image: wcygan/flock-api:latest
           ports:
             - containerPort: 8080
           resources:

--- a/flock-api/skaffold.yaml
+++ b/flock-api/skaffold.yaml
@@ -2,16 +2,6 @@ apiVersion: skaffold/v4beta1
 kind: Config
 metadata:
   name: flock-api-configuration
-build:
-  artifacts:
-    - image: flock-api
-      docker:
-        dockerfile: Dockerfile
-  tagPolicy:
-    sha256: {}
-  local:
-    useBuildkit: true
-    useDockerCLI: true
 manifests:
   rawYaml:
     - flock-api.yaml

--- a/flock-kc/skaffold.yaml
+++ b/flock-kc/skaffold.yaml
@@ -9,7 +9,7 @@ deploy:
         repo: https://charts.bitnami.com/bitnami
         remoteChart: keycloak
         version: 24.0.0
-        namespace: keycloak
+        namespace: default
         createNamespace: true
         wait: true
         valuesFiles:

--- a/flock-kc/values.yaml
+++ b/flock-kc/values.yaml
@@ -24,5 +24,78 @@ keycloakConfigCli:
         "registrationAllowed": true,
         "loginWithEmailAllowed": true,
         "duplicateEmailsAllowed": false,
-        "resetPasswordAllowed": true,
+        "resetPasswordAllowed": true
       }
+
+ingress:
+  enabled: true
+  ingressClassName: tailscale
+  hostname: auth.<custom-domain>.ts.net
+  tls: true
+  extraTls:
+    - hosts:
+        - auth.<custom-domain>.ts.net
+  paths:
+    - path: /
+      pathType: Prefix
+      backend:
+        name: keycloak
+        port:
+          name: http
+
+production: false
+proxy: edge
+
+## Disable TLS
+https:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 8080
+
+extraEnvVars:
+  - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
+    value: "true"
+  - name: KC_PROXY
+    value: "edge"
+  - name: KC_HTTP_ENABLED
+    value: "true"
+  - name: KEYCLOAK_PRODUCTION
+    value: "false"
+  - name: KC_HTTP_PORT
+    value: "8080"
+
+# Resource limits for development
+resources:
+  limits:
+    memory: "1Gi"
+    cpu: "1000m"
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+
+# Probes configuration
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 60
+  successThreshold: 1
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 300
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1

--- a/ingress/ingress.yaml
+++ b/ingress/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: flock-api-ingress
+spec:
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - api
+  rules:
+    - host: api
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: flock-api
+                port:
+                  number: 8080

--- a/ingress/skaffold.yaml
+++ b/ingress/skaffold.yaml
@@ -1,0 +1,23 @@
+apiVersion: skaffold/v4beta1
+kind: Config
+metadata:
+  name: ingress-installation
+deploy:
+  helm:
+    releases:
+      - name: ingress-nginx
+        namespace: ingress-nginx
+        createNamespace: true
+        repo: https://kubernetes.github.io/ingress-nginx
+        remoteChart: ingress-nginx
+        version: 4.11.3
+---
+apiVersion: skaffold/v4beta1
+kind: Config
+metadata:
+  name: ingress-configuration
+manifests:
+  rawYaml:
+    - ingress.yaml
+deploy:
+  kubectl: {}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,6 +8,9 @@ requires:
   - configs:
       - flock-api-configuration
     path: flock-api/skaffold.yaml
+  - configs:
+      - ingress-configuration
+    path: ingress/skaffold.yaml
 
 profiles:
   # This configures the infrastructure required for the application
@@ -25,3 +28,6 @@ profiles:
           - configs:
               - keycloak-installation
             path: flock-kc/skaffold.yaml
+          - configs:
+              - ingress-installation
+            path: ingress/skaffold.yaml


### PR DESCRIPTION
## Summary

Follow [Expose a Kubernetes cluster workload to your tailnet (cluster ingress)](https://tailscale.com/kb/1439/kubernetes-operator-cluster-ingress#exposing-cluster-workloads-using-a-kubernetes-ingress), exposing keycloak and frontend API through ingress-nginx

## Change Log

- Add `ingress-nginx` to the cluster
- Setup ingress routing for `keycloak` and `flock-api`
- Use latest docker image for `flock-api`

## Testing

Visit `https://auth.<domain>.ts.net/`

<img width="600" alt="Screenshot 2024-12-18 at 7 33 00 AM" src="https://github.com/user-attachments/assets/8eeaf98d-0b70-4e45-9190-6e4c63a672a5" />
