### PR TITLE
Add Telepresence to the Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,37 @@ Access the KeyCloak account console:
 ```bash
 open "https://$(kubectl get ing keycloak -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/realms/flock/account/"
 ```
+
+### Telepresence
+
+For UI:
+
+```bash
+telepresence intercept flock-web \
+  --namespace default \
+  --service flock-web \
+  --port 3000:http
+
+cd flock-web
+npm install
+npm run dev
+```
+
+For API:
+
+```bash
+telepresence intercept flock-api \
+  --namespace default \
+  --service flock-api \
+  --port 8080:8080
+
+cd flock-api
+go run cmd/main.go
+```
+
+When you're done:
+
+```bash
+telepresence leave flock-web
+telepresence leave flock-api
+```

--- a/README.md
+++ b/README.md
@@ -27,30 +27,38 @@ The API can be reached through our Ingress:
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  https://api.your-domain.ts.net/frontend.v1.ProfilePageService/GetProfilePage \
-  -d '{"username": "testuser"}'
+  "https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/frontend.v1.ProfilePageService/GetProfilePage" \
+  -d '{"username":"testuser"}'
 ```
 
 Here are other commands used for testing:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/frontend.v1.ProfilePageService/GetProfilePage -d '{"username": "testuser"}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/frontend.v1.ProfilePageService/GetProfilePage -d '{"username": "testuser"}'
 
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/frontend.v1.HomePageService/GetHomePage -d '{}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/frontend.v1.HomePageService/GetHomePage -d '{}'
 
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/backend.v1.PostService/CreatePost -d '{"author_id": 1, "content": "This is a new post"}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/backend.v1.PostService/CreatePost -d '{"author_id": 1, "content": "This is a new post"}'
 
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/backend.v1.PostService/GetPost -d '{"id": 123}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/backend.v1.PostService/GetPost -d '{"id": 123}'
 
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/backend.v1.PostService/BatchGetPosts -d '{"ids": ["123", "456", "789"]}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/backend.v1.PostService/BatchGetPosts -d '{"ids": ["123", "456", "789"]}'
 
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/backend.v1.PostService/ListMostRecentPosts -d '{"post_limit": 10}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/backend.v1.PostService/ListMostRecentPosts -d '{"post_limit": 10}'
 
-curl -X POST -H "Content-Type: application/json" http://localhost:8080/backend.v1.PostService/ListMostRecentPostsByUser -d '{"author": {"id": "1", "username": "testuser"}, "post_limit": 5}'
+curl -X POST -H "Content-Type: application/json" https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/backend.v1.PostService/ListMostRecentPostsByUser -d '{"author": {"id": "1", "username": "testuser"}, "post_limit": 5}'
 ```
 
 ### KeyCloak
 
-Visit https://auth.your-domain.ts.net/ to access the KeyCloak admin console.
+Access the KeyCloak admin console:
 
-Visit https://auth.your-domain.ts.net/realms/flock/account/ to access the KeyCloak account console (it redirects to the KeyCloak login page).
+```bash
+open "https://$(kubectl get ing keycloak -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+```
+
+Access the KeyCloak account console:
+
+```bash
+open "https://$(kubectl get ing keycloak -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/realms/flock/account/"
+```

--- a/documentation/telepresence.md
+++ b/documentation/telepresence.md
@@ -1,0 +1,71 @@
+# Teleprsenence
+
+## Why
+
+Telepresence is a tool that allows you to run a service locally while connecting to a remote Kubernetes cluster. This is useful for debugging or iterating on services that are running in a remote cluster.
+
+## How
+
+## Installation
+
+```bash
+# Install the telepresence CLI
+brew install telepresenceio/telepresence/telepresence-oss
+
+# Install the traffic manager
+telepresence helm install
+
+# Install the traffic agent
+telepresence connect
+
+# Check the status of the traffic agent
+telepresence list
+```
+
+If needed, it can be uninstalled with:
+
+```bash
+# Uninstall the traffic manager
+telepresence helm uninstall
+```
+
+### Flock-Web
+
+Make sure the app is running locally:
+
+```bash
+cd flock-web
+npm install
+npm run dev
+```
+
+Create an intercept for the service:
+
+```bash
+telepresence intercept flock-web \
+  --namespace default \
+  --service flock-web \
+  --port 3000:http
+```
+
+Next, visit <https://app.domain.ts.net/> to see the service running locally.
+
+The correct address for this can be derived through either of these commands:
+
+```bash
+open "https://$(kubectl get ing flock-web-ingress --no-headers \
+  | awk '{print $4}')"
+
+open "https://$(kubectl get ing flock-web-ingress \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+```
+
+Finally, begin making changes to the service locally. The changes will be reflected in the remote cluster when you connect over the ingress.
+
+When you're done, do this to clean up the intercept:
+
+```bash
+telepresence leave flock-web
+```
+
+## Flock-API

--- a/documentation/telepresence.md
+++ b/documentation/telepresence.md
@@ -6,7 +6,9 @@ Telepresence is a tool that allows you to run a service locally while connecting
 
 ## How
 
-## Installation
+Follow these steps to install and use Telepresence:
+
+### Installation
 
 ```bash
 # Install the telepresence CLI
@@ -53,6 +55,8 @@ Next, visit <https://app.domain.ts.net/> to see the service running locally.
 The correct address for this can be derived through either of these commands:
 
 ```bash
+kubectl get ing flock-web-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 
+
 open "https://$(kubectl get ing flock-web-ingress --no-headers \
   | awk '{print $4}')"
 
@@ -69,3 +73,78 @@ telepresence leave flock-web
 ```
 
 ## Flock-API
+
+The address for the app can be found at:
+
+```bash
+kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+Then, it can be used in this command:
+
+```bash
+domain=$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+curl -X POST \
+  -H "Content-Type: application/json" \
+  "https://${domain}/frontend.v1.ProfilePageService/GetProfilePage" \
+  -d '{"username": "testuser"}'
+```
+
+Or like this:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  "https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/frontend.v1.ProfilePageService/GetProfilePage" \
+  -d '{"username":"testuser"}'
+```
+
+Next, let's start the app, make a change, create an intercept, then try the `curl` again.
+
+Here is the small change:
+
+```diff
+diff --git a/flock-api/internal/profile_page/service.go b/flock-api/internal/profile_page/service.go
+index 39648fd..72f4fb4 100644
+--- a/flock-api/internal/profile_page/service.go
++++ b/flock-api/internal/profile_page/service.go
+@@ -13,5 +13,5 @@ func NewService() *Service {
+ }
+ 
+ func (s *Service) GetProfilePage(ctx context.Context, request *frontendv1.GetProfilePageRequest) (*frontendv1.GetProfilePageResponse, error) {
+-       return nil, errors.New("frontend.v1.ProfilePageService.GetProfilePage is not implemented")
++       return nil, errors.New("frontend.v1.ProfilePageService.GetProfilePage is not implemented yet")
+ }
+```
+
+Next, let's start the app:
+
+```bash
+cd flock-api
+go run cmd/main.go
+```
+
+Then, create an intercept:
+
+```bash
+telepresence intercept flock-api \
+  --namespace default \
+  --service flock-api \
+  --port 8080:8080
+```
+
+Finally, try the `curl` again:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  "https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/frontend.v1.ProfilePageService/GetProfilePage" \
+  -d '{"username":"testuser"}'
+{"code":"unimplemented","message":"frontend.v1.ProfilePageService.GetProfilePage is not implemented yet"}
+```
+
+When you're done, do this to clean up the intercept:
+
+```bash
+telepresence leave flock-api
+```

--- a/flock-api/internal/profile_page/service.go
+++ b/flock-api/internal/profile_page/service.go
@@ -13,5 +13,5 @@ func NewService() *Service {
 }
 
 func (s *Service) GetProfilePage(ctx context.Context, request *frontendv1.GetProfilePageRequest) (*frontendv1.GetProfilePageResponse, error) {
-	return nil, errors.New("frontend.v1.ProfilePageService.GetProfilePage is not implemented")
+	return nil, errors.New("frontend.v1.ProfilePageService.GetProfilePage is not implemented yet")
 }

--- a/flock-web/app/page.tsx
+++ b/flock-web/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
             </code>
             .
           </li>
-          <li>Save and see your changes instantly.</li>
+          <li>Save and see your changes instantly!</li>
         </ol>
 
         <div className="flex gap-4 items-center flex-col sm:flex-row">


### PR DESCRIPTION
## Summary

Add Telepresence to enable local, iterative development

## Change Log

- Added instructions for setting up [Telepresence](https://www.telepresence.io/)
- Changed the API slightly for testing
- Changed the UI slightly for testing

## Testing

First, connect the Telepresence agent:

```bash
telepresence connect
```

### UI

Visit the UI:

```bash
open "https://$(kubectl get ing flock-web-ingress \
  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
```

Start the app locally & make a small change:

```bash
cd flock-web
npm install
npm run dev
```

Enable an intercept for `flock-web` and see that the UI has changed:

```bash
telepresence intercept flock-web \
  --namespace default \
  --service flock-web \
  --port 3000:http
```

<img width="600" alt="image" src="https://github.com/user-attachments/assets/3b1fa5cf-6387-445f-93e6-00fa47b8d6ff" />

### API

Make a small change:

```diff
 func (s *Service) GetProfilePage(ctx context.Context, request *frontendv1.GetProfilePageRequest) (*frontendv1.GetProfilePageResponse, error) {
-       return nil, errors.New("frontend.v1.ProfilePageService.GetProfilePage is not implemented")
+       return nil, errors.New("frontend.v1.ProfilePageService.GetProfilePage is not implemented yet")
 }
```

Start the app locally:

```bash
cd flock-api
go run cmd/main.go
```

Create an intercept:

```bash
telepresence intercept flock-api \
  --namespace default \
  --service flock-api \
  --port 8080:8080
```


Try to `curl` this endpoint:

```bash
curl -X POST \
  -H "Content-Type: application/json" \
  "https://$(kubectl get ing flock-api-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')/frontend.v1.ProfilePageService/GetProfilePage" \
  -d '{"username":"testuser"}'
{"code":"unimplemented","message":"frontend.v1.ProfilePageService.GetProfilePage is not implemented yet"}
```