### PR TITLE
Use Keys instead of Strings for Entities in Protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Dependencies
 node_modules/
 
+# Build files
+gen
+
 # Environment variables
 **/.env
 .env

--- a/proto/backend/v1/post.proto
+++ b/proto/backend/v1/post.proto
@@ -22,13 +22,18 @@ service PostService {
   rpc ListMostRecentPostsByUser(ListMostRecentPostsByUserRequest) returns (ListMostRecentPostsByUserResponse);
 }
 
+// A unique key for a post.
+message PostKey {
+  string id = 1;
+}
+
 // A post is a message posted by a user.
 message Post {
   // The ID of the post.
-  int64 id = 1;
+  PostKey id = 1;
 
   // The author of the post.
-  Profile author = 2;
+  MiniProfile author = 2;
 
   // The content of the post.
   string content = 3;
@@ -40,7 +45,7 @@ message Post {
 // A request to create a post.
 message CreatePostRequest {
   // The author of the post.
-  int64 author_id = 1;
+  ProfileKey author = 1;
 
   // The content of the post.
   string content = 2;
@@ -55,7 +60,7 @@ message CreatePostResponse {
 // A request to get a post.
 message GetPostRequest {
   // The ID of the post to get.
-  int64 id = 1;
+  PostKey id = 1;
 }
 
 // Response for GetPost RPC.
@@ -67,7 +72,7 @@ message GetPostResponse {
 // A request to get a batch of posts by IDs.
 message BatchGetPostsRequest {
   // The IDs of the posts to get.
-  repeated string ids = 1;
+  repeated PostKey ids = 1;
 }
 
 // A response containing a batch of posts.
@@ -91,7 +96,7 @@ message ListMostRecentPostsResponse {
 // A request to list the most recent posts by a user.
 message ListMostRecentPostsByUserRequest {
   // The author whose posts to list.
-  Profile author = 1;
+  ProfileKey author = 1;
 
   // The maximum number of posts to return.
   int32 post_limit = 2;

--- a/proto/backend/v1/profile.proto
+++ b/proto/backend/v1/profile.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 
 package backend.v1;
 
+// A unique key for a profile.
+message ProfileKey {
+  string id = 1;
+}
+
 // Detailed user information. Used to render the Profile page.
 message Profile {
   MiniProfile summary = 1;
@@ -10,11 +15,11 @@ message Profile {
 
 // Basic user information.
 message MiniProfile {
-  string id = 1;
+  ProfileKey key = 1;
   string username = 2;
   string first_name = 3;
   string last_name = 4;
-  ProfilePicture profile_picture = 5;
+  optional ProfilePicture profile_picture = 5;
 }
 
 // Profile picture information.

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -5,4 +5,4 @@ breaking:
     - FILE
 lint:
   use:
-    - DEFAULT
+    - STANDARD

--- a/proto/frontend/v1/profile_page.proto
+++ b/proto/frontend/v1/profile_page.proto
@@ -21,6 +21,6 @@ message GetProfilePageResponse {
 
 // Request for getting a user's profile page.
 message GetProfilePageRequest {
-  // The username of the profile to fetch
-  string username = 1;
+  // The key of the profile to fetch
+  backend.v1.ProfileKey profile = 1;
 }


### PR DESCRIPTION
## Summary

Use "Keys" instead of ints for Entities in Protobuf

We cannot specify `int32` or `int64` to be the primary keys since they will likely be stored as one of these options in the DB:

1. [UUIDv7](https://uuid7.com/)
2. [ULID](https://github.com/ulid/spec)
3. [NanoID](https://github.com/ai/nanoid) 

By doing this, we make our schemas more flexible to accommodate different ways of identifying individual entities

Additional references:

- https://planetscale.com/blog/the-problem-with-using-a-uuid-primary-key-in-mysql
- https://planetscale.com/blog/why-we-chose-nanoids-for-planetscales-api

## Change Log

- **Refactor:** Use `Key` for Post
- **Refactor:** Use `Key` for Profile
- **Refactor:** Make `ProfilePicture` optional

## Testing

Validations are passing locally:

```bash
buf lint proto
buf generate proto
```