### PR TITLE
Stub implementation for unimplemented pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ The tailnet is scrubbed (it is not actually `your-domain.ts.net`), so the comman
 
 ## Testing
 
+### UI
+
+Visit the UI here:
+
+```bash
+open "https://$(kubectl get ing flock-web-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+```
+
 ### API
 
 The API can be reached through our Ingress:

--- a/documentation/flock-web.md
+++ b/documentation/flock-web.md
@@ -18,7 +18,7 @@ Ensure you have a `.env.local` file in the `flock-web` folder with the following
 KEYCLOAK_CLIENT_ID=flock-web
 KEYCLOAK_CLIENT_SECRET=<from keycloak>
 KEYCLOAK_ISSUER=<flock realm URL>
-NEXTAUTH_URL=<flock-web url>
+NEXT_PUBLIC_FLOCK_API_URL=<tailnet domain>
 AUTH_SECRET=<ask wcygan>
 ```
 

--- a/documentation/kubernetes.md
+++ b/documentation/kubernetes.md
@@ -1,0 +1,15 @@
+# Kubernetes FAQ
+
+## Deploy latest images to Kubernetes
+
+Did you just merge a PR and push a new image to Docker Hub? You can deploy the latest images to Kubernetes by running the following commands:
+
+```bash
+kubectl rollout restart deployment flock-web
+kubectl rollout restart deployment flock-api
+```
+
+That will correspond to the `flock-web` and `flock-api` deployments respectively. Their images are hosted on Docker Hub:
+
+- https://hub.docker.com/r/wcygan/flock-api
+- https://hub.docker.com/r/wcygan/flock-web

--- a/flock-web/app/discover/[query]/page.tsx
+++ b/flock-web/app/discover/[query]/page.tsx
@@ -1,0 +1,22 @@
+import { Card } from "@/components/ui/card";
+
+export default function DiscoverPage({
+  params,
+}: {
+  params: { query: string };
+}) {
+  const decodedQuery = decodeURIComponent(params.query);
+
+  return (
+    <div className="flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-4 mb-4">
+          <h1 className="text-xl font-semibold">
+            Showing all results for "{decodedQuery}"
+          </h1>
+        </Card>
+        {/* Add your search results here */}
+      </main>
+    </div>
+  );
+}

--- a/flock-web/app/discover/page.tsx
+++ b/flock-web/app/discover/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from "@/components/ui/card";
+
+export default function DiscoverLandingPage() {
+  return (
+    <div className="flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-4">
+          <h1 className="text-xl font-semibold mb-4">Discover</h1>
+          <p className="text-muted-foreground">
+            Start exploring by typing in the search bar above.
+          </p>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/flock-web/app/layout.tsx
+++ b/flock-web/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css"
 import { Sidebar } from "@/components/sidebar"
 import { AuthProvider } from "./auth-provider"
 import { ToastProvider } from "@/components/ui/toaster"
+import { Header } from "@/components/header"
 import {getCustomServerSession} from "@/lib/auth";
 
 const inter = Inter({ subsets: ["latin"] })
@@ -26,7 +27,12 @@ export default async function RootLayout({
         <AuthProvider session={session}>
           <div className="flex min-h-screen">
             <Sidebar />
-            {children}
+            <div className="flex-1">
+              <Header />
+              <main className="flex-1">
+                {children}
+              </main>
+            </div>
           </div>
           <ToastProvider />
         </AuthProvider>

--- a/flock-web/app/messages/page.tsx
+++ b/flock-web/app/messages/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from "@/components/ui/card";
+
+export default function MessagesPage() {
+  return (
+    <div className="flex-1 flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-8 text-center">
+          <h2 className="text-2xl font-semibold mb-2">Under Construction</h2>
+          <p className="text-muted-foreground">
+            The messages page is currently being worked on. Please check back later!
+          </p>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/flock-web/app/notifications/page.tsx
+++ b/flock-web/app/notifications/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from "@/components/ui/card";
+
+export default function NotificationsPage() {
+  return (
+    <div className="flex-1 flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-8 text-center">
+          <h2 className="text-2xl font-semibold mb-2">Under Construction</h2>
+          <p className="text-muted-foreground">
+            The notifications page is currently being worked on. Please check back later!
+          </p>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -4,13 +4,11 @@ import { getCustomServerSession } from "@/lib/auth";
 import { getColorFromUsername } from "@/lib/utils";
 
 export default async function ProfilePage({ params }: { params: { id: string } }) {
-  // Await the async operation
   const session = await getCustomServerSession();
+
+  // This needs to be async
+  const { id } = await params;
   
-  // Access params.id directly (it's synchronous)
-  const id = params.id;
-  
-  // Now we can safely use the values
   const isCurrentUser = id === session?.user?.user_id;
   
   return (

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -4,8 +4,14 @@ import { getCustomServerSession } from "@/lib/auth";
 import { getColorFromUsername } from "@/lib/utils";
 
 export default async function ProfilePage({ params }: { params: { id: string } }) {
-  const session = await getCustomServerSession();
-  const isCurrentUser = params.id === session?.user?.user_id;
+  // Await all async operations first
+  const [session, id] = await Promise.all([
+    getCustomServerSession(),
+    params.id
+  ]);
+
+  // Now we can safely use the values
+  const isCurrentUser = id === session?.user?.user_id;
   
   return (
     <div className="flex-1 flex gap-4 p-4">

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -1,0 +1,46 @@
+import { Card } from "@/components/ui/card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { getCustomServerSession } from "@/lib/auth";
+
+function hashUsername(username: string): string {
+  let hash = 0;
+  for (let i = 0; i < username.length; i++) {
+    hash = username.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return (hash & 0x00FFFFFF).toString(16).toUpperCase().padStart(6, '0');
+}
+
+export default async function ProfilePage({ params }: { params: { id: string } }) {
+  const session = await getCustomServerSession();
+  const isCurrentUser = params.id === session?.user?.id;
+  const profileColor = hashUsername(session?.user?.username || 'user');
+  
+  return (
+    <div className="flex-1 flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-8">
+          <div className="flex flex-col items-center gap-4 mb-8">
+            <Avatar className="h-24 w-24" style={{ backgroundColor: `#${profileColor}` }}>
+              <AvatarFallback className="text-3xl">
+                {session?.user?.name?.charAt(0)}
+              </AvatarFallback>
+            </Avatar>
+            <h2 className="text-2xl font-semibold">
+              {session?.user?.name}
+            </h2>
+            <p className="text-muted-foreground">
+              @{session?.user?.username}
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Posts</h3>
+            <Card className="p-4 text-center text-muted-foreground">
+              No posts yet
+            </Card>
+          </div>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -14,6 +14,7 @@ export default async function ProfilePage({ params }: { params: { id: string } }
   const session = await getCustomServerSession();
   const isCurrentUser = params.id === session?.user?.user_id;
   const profileColor = hashUsername(session?.user?.username || 'user');
+  console.log("Color: ", profileColor);
   
   return (
     <div className="flex-1 flex gap-4 p-4">

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -4,12 +4,12 @@ import { getCustomServerSession } from "@/lib/auth";
 import { getColorFromUsername } from "@/lib/utils";
 
 export default async function ProfilePage({ params }: { params: { id: string } }) {
-  // Await all async operations first
-  const [session, id] = await Promise.all([
-    getCustomServerSession(),
-    params.id
-  ]);
-
+  // Await the async operation
+  const session = await getCustomServerSession();
+  
+  // Access params.id directly (it's synchronous)
+  const id = params.id;
+  
   // Now we can safely use the values
   const isCurrentUser = id === session?.user?.user_id;
   

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -16,7 +16,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   const isCurrentUser = id === session?.user?.user_id;
   
   return (
-    <div className="flex-1 flex gap-4 p-4">
+    <div className="flex gap-4 p-4">
       <main className="flex-1 max-w-2xl mx-auto">
         <Card className="p-8">
           <div className="flex flex-col items-center gap-4 mb-8">

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -30,6 +30,11 @@ export default async function ProfilePage({ params }: { params: { id: string } }
             <p className="text-muted-foreground">
               @{session?.user?.username}
             </p>
+            {isCurrentUser && (
+              <div className="text-center text-green-600 font-medium mt-2">
+                Welcome to your profile!
+              </div>
+            )}
           </div>
 
           <div className="space-y-4">

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -1,28 +1,22 @@
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { getCustomServerSession } from "@/lib/auth";
-
-function hashUsername(username: string): string {
-  let hash = 0;
-  for (let i = 0; i < username.length; i++) {
-    hash = username.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return (hash & 0x00FFFFFF).toString(16).toUpperCase().padStart(6, '0');
-}
+import { getColorFromUsername } from "@/lib/utils";
 
 export default async function ProfilePage({ params }: { params: { id: string } }) {
   const session = await getCustomServerSession();
   const isCurrentUser = params.id === session?.user?.user_id;
-  const profileColor = hashUsername(session?.user?.username || 'user');
-  console.log("Color: ", profileColor);
   
   return (
     <div className="flex-1 flex gap-4 p-4">
       <main className="flex-1 max-w-2xl mx-auto">
         <Card className="p-8">
           <div className="flex flex-col items-center gap-4 mb-8">
-            <Avatar className="h-24 w-24" style={{ backgroundColor: `#${profileColor}` }}>
-              <AvatarFallback className="text-3xl">
+            <Avatar className="h-24 w-24">
+              <AvatarFallback 
+                style={{ backgroundColor: getColorFromUsername(session?.user?.username || 'user') }}
+                className="text-3xl text-white"
+              >
                 {session?.user?.name?.charAt(0)}
               </AvatarFallback>
             </Avatar>

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -6,8 +6,8 @@ import { getColorFromUsername } from "@/lib/utils";
 export default async function ProfilePage({ params }: { params: { id: string } }) {
   const session = await getCustomServerSession();
 
-  // This needs to be async
-  const { id } = await params;
+  // Access params.id directly (it's synchronous)
+  const { id } = params;
   
   const isCurrentUser = id === session?.user?.user_id;
   

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -3,11 +3,15 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { getCustomServerSession } from "@/lib/auth";
 import { getColorFromUsername } from "@/lib/utils";
 
-export default async function ProfilePage({ params }: { params: { id: string } }) {
+type ProfilePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
   const session = await getCustomServerSession();
 
   // Access params.id directly (it's synchronous)
-  const { id } = params;
+  const { id } = await params;
   
   const isCurrentUser = id === session?.user?.user_id;
   

--- a/flock-web/app/profile/[id]/page.tsx
+++ b/flock-web/app/profile/[id]/page.tsx
@@ -12,7 +12,7 @@ function hashUsername(username: string): string {
 
 export default async function ProfilePage({ params }: { params: { id: string } }) {
   const session = await getCustomServerSession();
-  const isCurrentUser = params.id === session?.user?.id;
+  const isCurrentUser = params.id === session?.user?.user_id;
   const profileColor = hashUsername(session?.user?.username || 'user');
   
   return (

--- a/flock-web/app/profile/page.tsx
+++ b/flock-web/app/profile/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from "@/components/ui/card";
+
+export default function ProfilePage() {
+  return (
+    <div className="flex-1 flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-8 text-center">
+          <h2 className="text-2xl font-semibold mb-2">Under Construction</h2>
+          <p className="text-muted-foreground">
+            The profile page is currently being worked on. Please check back later!
+          </p>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/flock-web/app/settings/page.tsx
+++ b/flock-web/app/settings/page.tsx
@@ -1,0 +1,16 @@
+import { Card } from "@/components/ui/card";
+
+export default function SettingsPage() {
+  return (
+    <div className="flex-1 flex gap-4 p-4">
+      <main className="flex-1 max-w-2xl mx-auto">
+        <Card className="p-8 text-center">
+          <h2 className="text-2xl font-semibold mb-2">Under Construction</h2>
+          <p className="text-muted-foreground">
+            The settings page is currently being worked on. Please check back later!
+          </p>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/flock-web/components/header.tsx
+++ b/flock-web/components/header.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-40 w-full border-b bg-background">
+      <div className="container flex h-16 items-center gap-4 px-4">
+        <div className="flex-1">
+          <Input
+            type="search"
+            placeholder="Search Flock"
+            className="w-full max-w-[400px] bg-muted/50"
+          />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/flock-web/components/header.tsx
+++ b/flock-web/components/header.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
 
 export function Header() {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
@@ -15,11 +18,19 @@ export function Header() {
     }
   };
 
+  // Clear search input on route change
+  useEffect(() => {
+    if (searchInputRef.current) {
+      searchInputRef.current.value = '';
+    }
+  }, [pathname]);
+
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background">
       <div className="container flex h-16 items-center justify-center px-4">
         <div className="w-[65%] flex justify-center">
           <Input
+            ref={searchInputRef}
             type="search"
             placeholder="Search Flock"
             className="w-full bg-muted/50"

--- a/flock-web/components/header.tsx
+++ b/flock-web/components/header.tsx
@@ -1,8 +1,20 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
+import { useRouter } from "next/navigation";
 
 export function Header() {
+  const router = useRouter();
+
+  const handleSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      const query = e.currentTarget.value.trim();
+      if (query) {
+        router.push(`/discover/${encodeURIComponent(query)}`);
+      }
+    }
+  };
+
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background">
       <div className="container flex h-16 items-center justify-center px-4">
@@ -11,6 +23,7 @@ export function Header() {
             type="search"
             placeholder="Search Flock"
             className="w-full bg-muted/50"
+            onKeyDown={handleSearch}
           />
         </div>
       </div>

--- a/flock-web/components/header.tsx
+++ b/flock-web/components/header.tsx
@@ -5,12 +5,12 @@ import { Input } from "@/components/ui/input";
 export function Header() {
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background">
-      <div className="container flex h-16 items-center gap-4 px-4">
-        <div className="flex-1">
+      <div className="container flex h-16 items-center justify-center px-4">
+        <div className="w-[65%] flex justify-center">
           <Input
             type="search"
             placeholder="Search Flock"
-            className="w-full max-w-[400px] bg-muted/50"
+            className="w-full bg-muted/50"
           />
         </div>
       </div>

--- a/flock-web/components/home-page.tsx
+++ b/flock-web/components/home-page.tsx
@@ -11,7 +11,7 @@ export function HomePage() {
   const posts = usePosts();
 
   return (
-    <div className="flex-1 flex gap-4 p-4">
+    <div className="flex gap-4 p-4">
       <main className="flex-1 max-w-2xl mx-auto">
         <div className="space-y-4">
           {posts.map((post) => (

--- a/flock-web/components/home-page.tsx
+++ b/flock-web/components/home-page.tsx
@@ -5,6 +5,7 @@ import { usePosts } from "@/hooks/usePosts";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
+import { getColorFromUsername } from "@/lib/utils";
 
 export function HomePage() {
   const posts = usePosts();

--- a/flock-web/components/home-page.tsx
+++ b/flock-web/components/home-page.tsx
@@ -24,7 +24,10 @@ export function HomePage() {
             <Card key={post.id!.id} className="p-4">
               <div className="flex gap-3">
                 <Avatar className="h-10 w-10">
-                  <AvatarFallback>
+                  <AvatarFallback 
+                    style={{ backgroundColor: getColorFromUsername(post.author!.username) }}
+                    className="text-white"
+                  >
                     {post.author!.firstName[0]}{post.author!.lastName[0]}
                   </AvatarFallback>
                 </Avatar>
@@ -71,7 +74,12 @@ export function HomePage() {
               {[1, 2, 3].map((i) => (
                 <div key={i} className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <Avatar className="h-8 w-8" />
+                    <Avatar className="h-8 w-8">
+                      <AvatarFallback 
+                        style={{ backgroundColor: getColorFromUsername("username") }}
+                        className="text-white"
+                      />
+                    </Avatar>
                     <div className="text-sm">
                       <div className="font-medium">User Name</div>
                       <div className="text-muted-foreground">@username</div>

--- a/flock-web/components/home-page.tsx
+++ b/flock-web/components/home-page.tsx
@@ -13,13 +13,6 @@ export function HomePage() {
   return (
     <div className="flex-1 flex gap-4 p-4">
       <main className="flex-1 max-w-2xl mx-auto">
-        <div className="mb-4">
-          <Input
-            type="search"
-            placeholder="Search Flock"
-            className="w-full bg-muted/50"
-          />
-        </div>
         <div className="space-y-4">
           {posts.map((post) => (
             <Card key={post.id!.id} className="p-4">

--- a/flock-web/components/sidebar.tsx
+++ b/flock-web/components/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Home, Bell, MessageSquare, User, Settings } from "lucide-react"
+import { Home, Bell, MessageSquare, User, Settings, Search } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { SidebarNavButton } from "@/components/ui/sidebar-nav-button"
 import { Session } from "next-auth"
@@ -39,6 +39,7 @@ export function Sidebar() {
         <nav className="space-y-2">
           <SidebarNavButton href="/" icon={Home}>Home</SidebarNavButton>
           <SidebarNavButton href={`/profile/${session?.user?.user_id}`} icon={User}>Profile</SidebarNavButton>
+          <SidebarNavButton href="/discover" icon={Search}>Discover</SidebarNavButton>
           <SidebarNavButton href="/notifications" icon={Bell}>Notifications</SidebarNavButton>
           <SidebarNavButton href="/messages" icon={MessageSquare}>Messages</SidebarNavButton>
           <SidebarNavButton href="/settings" icon={Settings}>Settings</SidebarNavButton>

--- a/flock-web/components/sidebar.tsx
+++ b/flock-web/components/sidebar.tsx
@@ -29,13 +29,6 @@ export function Sidebar() {
           <span className="font-semibold text-xl">Flock</span>
         </div>
 
-        <div className="mb-4">
-          <Input
-            type="search"
-            placeholder="Search Flock"
-            className="w-full bg-muted/50"
-          />
-        </div>
 
         {session?.user?.name ? (
           <div className="px-2 py-2 text-sm text-muted-foreground bg-muted/50 rounded-lg">

--- a/flock-web/components/sidebar.tsx
+++ b/flock-web/components/sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar() {
           <SidebarNavButton href="/" icon={Home}>Home</SidebarNavButton>
           <SidebarNavButton href="/notifications" icon={Bell}>Notifications</SidebarNavButton>
           <SidebarNavButton href="/messages" icon={MessageSquare}>Messages</SidebarNavButton>
-          <SidebarNavButton href="/profile" icon={User}>Profile</SidebarNavButton>
+          <SidebarNavButton href={`/profile/${session?.user?.id}`} icon={User}>Profile</SidebarNavButton>
           <SidebarNavButton href="/settings" icon={Settings}>Settings</SidebarNavButton>
         </nav>
 

--- a/flock-web/components/sidebar.tsx
+++ b/flock-web/components/sidebar.tsx
@@ -36,9 +36,9 @@ export function Sidebar() {
 
         <nav className="space-y-2">
           <SidebarNavButton href="/" icon={Home}>Home</SidebarNavButton>
+          <SidebarNavButton href={`/profile/${session?.user?.user_id}`} icon={User}>Profile</SidebarNavButton>
           <SidebarNavButton href="/notifications" icon={Bell}>Notifications</SidebarNavButton>
           <SidebarNavButton href="/messages" icon={MessageSquare}>Messages</SidebarNavButton>
-          <SidebarNavButton href={`/profile/${session?.user?.user_id}`} icon={User}>Profile</SidebarNavButton>
           <SidebarNavButton href="/settings" icon={Settings}>Settings</SidebarNavButton>
         </nav>
 

--- a/flock-web/components/sidebar.tsx
+++ b/flock-web/components/sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar() {
           <SidebarNavButton href="/" icon={Home}>Home</SidebarNavButton>
           <SidebarNavButton href="/notifications" icon={Bell}>Notifications</SidebarNavButton>
           <SidebarNavButton href="/messages" icon={MessageSquare}>Messages</SidebarNavButton>
-          <SidebarNavButton href={`/profile/${session?.user?.id}`} icon={User}>Profile</SidebarNavButton>
+          <SidebarNavButton href={`/profile/${session?.user?.user_id}`} icon={User}>Profile</SidebarNavButton>
           <SidebarNavButton href="/settings" icon={Settings}>Settings</SidebarNavButton>
         </nav>
 

--- a/flock-web/components/sidebar.tsx
+++ b/flock-web/components/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Home, Bell, MessageSquare, User, Settings } from "lucide-react"
+import { Input } from "@/components/ui/input"
 import { SidebarNavButton } from "@/components/ui/sidebar-nav-button"
 import { Session } from "next-auth"
 import { LogoutButton } from "./logout-button"
@@ -26,6 +27,14 @@ export function Sidebar() {
         <div className="flex items-center gap-2 px-2 py-4">
           <div className="h-6 w-6 rounded-full bg-emerald-500" />
           <span className="font-semibold text-xl">Flock</span>
+        </div>
+
+        <div className="mb-4">
+          <Input
+            type="search"
+            placeholder="Search Flock"
+            className="w-full bg-muted/50"
+          />
         </div>
 
         {session?.user?.name ? (

--- a/flock-web/components/ui/sidebar-nav-button.tsx
+++ b/flock-web/components/ui/sidebar-nav-button.tsx
@@ -17,7 +17,7 @@ export function SidebarNavButton({ href, icon: Icon, children }: SidebarNavButto
     <Link href={href}>
       <Button 
         variant="ghost" 
-        className={`w-full justify-start gap-2 ${isActive ? 'bg-accent/50 hover:bg-accent/50' : ''}`}
+        className={`w-full justify-start gap-2 ${isActive ? 'bg-accent/70 hover:bg-accent/70' : ''}`}
       >
         <Icon className="h-5 w-5" />
         {children}

--- a/flock-web/components/ui/sidebar-nav-button.tsx
+++ b/flock-web/components/ui/sidebar-nav-button.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { LucideIcon } from "lucide-react"
+import { usePathname } from "next/navigation"
 
 interface SidebarNavButtonProps {
   href: string
@@ -9,9 +10,15 @@ interface SidebarNavButtonProps {
 }
 
 export function SidebarNavButton({ href, icon: Icon, children }: SidebarNavButtonProps) {
+  const pathname = usePathname()
+  const isActive = pathname === href
+
   return (
     <Link href={href}>
-      <Button variant="ghost" className="w-full justify-start gap-2">
+      <Button 
+        variant="ghost" 
+        className={`w-full justify-start gap-2 ${isActive ? 'bg-accent/50 hover:bg-accent/50' : ''}`}
+      >
         <Icon className="h-5 w-5" />
         {children}
       </Button>

--- a/flock-web/k8s/deployment.yaml
+++ b/flock-web/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: tailnet-domain
-                  key: url
+                  key: api-origin
             - name: KEYCLOAK_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/flock-web/lib/api-client.ts
+++ b/flock-web/lib/api-client.ts
@@ -4,16 +4,8 @@ import { PostService } from "@buf/wcygan_flock.connectrpc_es/backend/v1/post_con
 import { HomePageService } from "@buf/wcygan_flock.connectrpc_es/frontend/v1/home_page_connect";
 import { ProfilePageService } from "@buf/wcygan_flock.connectrpc_es/frontend/v1/profile_page_connect";
 
-const API_URL = "https://api." + process.env.NEXT_PUBLIC_FLOCK_API_URL;
-
-if (!API_URL) {
-  throw new Error("NEXT_PUBLIC_FLOCK_API_URL environment variable is not defined");
-} else {
-    console.log("API_URL is defined: ", API_URL);
-}
-
 const transport = createConnectTransport({
-  baseUrl: API_URL,
+  baseUrl: process.env.NEXT_PUBLIC_FLOCK_API_URL!,
 });
 
 // console.log("Origin:", window.location.host);

--- a/flock-web/lib/utils.ts
+++ b/flock-web/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getColorFromUsername(username: string): string {
+  // Take first 6 characters of the username hash
+  const hash = username.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  const hex = (hash & 0xFFFFFF).toString(16).padStart(6, '0');
+  return `#${hex}`;
+}

--- a/flock-web/types/index.ts
+++ b/flock-web/types/index.ts
@@ -2,10 +2,13 @@ import { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
   interface Session extends DefaultSession {
+    accessToken?: string;
     user?: {
       id: string;
+      user_id: string;
       name?: string | null;
       email?: string | null;
+      username?: string | null;
       image?: string | null;
     };
   }


### PR DESCRIPTION
## Summary

I added a stub implementation to most pages

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/badeeeb7-2259-4d59-8db6-09d423962432" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b3187a09-c024-4cd5-b9a6-638bcc70da96" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f90789a8-d912-4df7-bc8d-6d84927164e3" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/da7d0fce-c08d-46a0-97b3-f34d32a73c7c" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/901ea752-b34b-43ab-a762-740dff33915b" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/53d21c44-a2c5-4d49-b941-f386d34f47f7" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/146e6d03-7e5c-4a99-9b80-3bb561e7447a" />

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/bc9e2966-e759-4d08-b804-d746183f97e8" />

## Change Log

- **Feature:** Added discover page
- **Feature:** Created profile picture color based on hashed username
- **Refactor:** Widened and centered the search bar
- **Refactor:** Added stub for profile, discover, notifications, messages, and settings pages
- **Refactor:** Extend session to include other fields

## Testing

```bash
open "https://$(kubectl get ing flock-web-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
cd flock-web
./scripts/live-reload-in-k8s.sh
```
