### PR TITLE
fix image pull policy

### DIFF
--- a/flock-api/flock-api.yaml
+++ b/flock-api/flock-api.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: flock-api
           image: wcygan/flock-api:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           env:

--- a/flock-web/k8s/deployment.yaml
+++ b/flock-web/k8s/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
         - name: flock-web
           image: wcygan/flock-web:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Problem & Solution

**Problem**: I was uploading new images for `flock-web`, then doing `kubectl rollout restart deployment flock-web`, but I didn't see the update that I was looking for!

**Solution**: Use pull policy [always](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy)

> every time the kubelet launches a container, the kubelet queries the container image registry to resolve the name to an image [digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier). If the kubelet has a container image with that exact digest cached locally, the kubelet uses its cached image; otherwise, the kubelet pulls the image with the resolved digest, and uses that image to launch the container.

This is useful since our CI is pushing `:latest` images for [flock-web](https://github.com/flock-eng/flock/blob/19f173e8506224956393334f20b2efebc60b80bd/.github/workflows/flock-web.yaml#L117) and [flock-api](https://github.com/flock-eng/flock/blob/19f173e8506224956393334f20b2efebc60b80bd/.github/workflows/flock-api.yaml#L117), and the kubelet can detect a difference in digests

## Testing

```bash
kubectl apply -f flock-web/k8s/deployment.yaml
kubectl rollout restart deployment flock-web
```

Now the new image is being used properly